### PR TITLE
Atualização Errata PIU Setor Central 2

### DIFF
--- a/erratas/43.json
+++ b/erratas/43.json
@@ -1,6 +1,6 @@
 {	
 	"descricao": "Lista de erros da consulta do PIU Setor 2",
-	"urlConsulta": "http://participe.gestaourbana.prefeitura.sp.gov.br/setor-central-2/",
+	"urlConsulta": "https://participe.gestaourbana.prefeitura.sp.gov.br/setor-central-2/",
 	"erros": [
 		{
 			"id": 1,
@@ -55,11 +55,11 @@
 			"atualizacao": "2019-05-14",
 			"conteudoAntigo": {
 				"tipo": "imagem",
-				"conteudo": "https://participe.gestaourbana.prefeitura.sp.gov.br/arquivos/setor-central-2/errata/tabela1-antiga.jpg"
+				"conteudo": "http://participe.comunicacao.smul.pmsp/arquivos/setor-central-2/errata/tabela1-antiga.jpg"
 			},
 			"conteudoNovo": { 
 				"tipo": "imagem",
-				"conteudo": "https://participe.gestaourbana.prefeitura.sp.gov.br/arquivos/setor-central-2/errata/tabela1-2019-05-10.jpg"
+				"conteudo": "http://participe.comunicacao.smul.pmsp/arquivos/setor-central-2/errata/tabela1-2019-05-10.jpg"
 			 }
 		},
 		{
@@ -139,11 +139,11 @@
 			"atualizacao": "2019-05-14",
 			"conteudoAntigo": {
 				"tipo": "imagem",
-				"conteudo": "https://participe.gestaourbana.prefeitura.sp.gov.br/arquivos/setor-central-2/errata/tabela2-antiga.jpg"
+				"conteudo": "http://participe.comunicacao.smul.pmsp/arquivos/setor-central-2/errata/tabela2-antiga.jpg"
 			},
 			"conteudoNovo": { 
 				"tipo": "imagem",
-				"conteudo": "https://participe.gestaourbana.prefeitura.sp.gov.br/arquivos/setor-central-2/errata/tabela2-2019-05-10.jpg"
+				"conteudo": "http://participe.comunicacao.smul.pmsp/arquivos/setor-central-2/errata/tabela2-2019-05-10.jpg"
 			 }
 		},
 		{
@@ -151,11 +151,11 @@
 			"atualizacao": "2019-05-14",
 			"conteudoAntigo": {
 				"tipo": "imagem",
-				"conteudo": "https://participe.gestaourbana.prefeitura.sp.gov.br/arquivos/setor-central-2/img/distribuicao-estoque.png"
+				"conteudo": "http://participe.comunicacao.smul.pmsp/arquivos/setor-central-2/img/distribuicao-estoque.png"
 			},
 			"conteudoNovo": { 
 				"tipo": "imagem",
-				"conteudo": "https://participe.gestaourbana.prefeitura.sp.gov.br/arquivos/setor-central-2/img/distribuicao-estoque_2019-05-10.png"
+				"conteudo": "http://participe.comunicacao.smul.pmsp/arquivos/setor-central-2/img/distribuicao-estoque_2019-05-10.png"
 			 }
 		},
 		{
@@ -163,23 +163,47 @@
 			"atualizacao": "2019-05-14",
 			"conteudoAntigo": {
 				"tipo": "imagem",
-				"conteudo": "https://participe.gestaourbana.prefeitura.sp.gov.br/arquivos/setor-central-2/antes-depois/eixo-transf-minhocao_depois.jpg"
+				"conteudo": "http://participe.comunicacao.smul.pmsp/arquivos/setor-central-2/antes-depois/eixo-transf-minhocao_depois.jpg"
 			},
 			"conteudoNovo": { 
 				"tipo": "imagem",
-				"conteudo": "https://participe.gestaourbana.prefeitura.sp.gov.br/arquivos/setor-central-2/antes-depois/eixo-transf-minhocao_depois_2019-05-14.jpg"
+				"conteudo": "http://participe.comunicacao.smul.pmsp/arquivos/setor-central-2/antes-depois/eixo-transf-minhocao_depois_2019-05-14.jpg"
 			 }
 		},
 		{
 			"id": 15,
-			"atualizacao": "2019-05-14",
+			"atualizacao": "2019-05-15",
 			"conteudoAntigo": {
 				"tipo": "imagem",
-				"conteudo": "https://participe.gestaourbana.prefeitura.sp.gov.br/arquivos/setor-central-2/antes-depois/eixo-transf_depois.jpg"
+				"conteudo": "http://participe.comunicacao.smul.pmsp/arquivos/setor-central-2/antes-depois/eixo-ordena-paisa-4_depois.jpg"
 			},
 			"conteudoNovo": { 
 				"tipo": "imagem",
-				"conteudo": "https://participe.gestaourbana.prefeitura.sp.gov.br/arquivos/setor-central-2/antes-depois/eixo-transf_depois_2019-05-14.jpg"
+				"conteudo": "http://participe.comunicacao.smul.pmsp/arquivos/setor-central-2/antes-depois/eixo-ordena-paisa-4_depois_2019-05-15.jpg"
+			 }
+		},
+		{
+			"id": 16,
+			"atualizacao": "2019-05-17",
+			"conteudoAntigo": {
+				"tipo": "imagem",
+				"conteudo": "http://participe.comunicacao.smul.pmsp/arquivos/setor-central-2/antes-depois/eixo-transf-orla_antes.jpg"
+			},
+			"conteudoNovo": { 
+				"tipo": "imagem",
+				"conteudo": "http://participe.comunicacao.smul.pmsp/arquivos/setor-central-2/antes-depois/eixo-transf-orla_antes_2019-05-17.jpg"
+			 }
+		},
+		{
+			"id": 16,
+			"atualizacao": "2019-05-17",
+			"conteudoAntigo": {
+				"tipo": "imagem",
+				"conteudo": "http://participe.comunicacao.smul.pmsp/arquivos/setor-central-2/antes-depois/eixo-transf-orla_depois.jpg"
+			},
+			"conteudoNovo": { 
+				"tipo": "imagem",
+				"conteudo": "http://participe.comunicacao.smul.pmsp/arquivos/setor-central-2/antes-depois/eixo-transf-orla_depois_2019-05-17.jpg"
 			 }
 		}
 	]

--- a/erratas/43.json
+++ b/erratas/43.json
@@ -205,6 +205,18 @@
 				"tipo": "imagem",
 				"conteudo": "https://participe.gestaourbana.prefeitura.sp.gov.br/arquivos/setor-central-2/antes-depois/eixo-transf-orla_depois_2019-05-17.jpg"
 			 }
+		},
+		{
+			"id": 17,
+			"atualizacao": "2019-05-24",
+			"conteudoAntigo": {
+				"tipo": "imagem",
+				"conteudo": "https://participe.gestaourbana.prefeitura.sp.gov.br/arquivos/setor-central-2/errata/tabela-grupogestor-antiga.jpg"
+			},
+			"conteudoNovo": { 
+				"tipo": "imagem",
+				"conteudo": "https://participe.gestaourbana.prefeitura.sp.gov.br/arquivos/setor-central-2/errata/tabela-grupogestor-2019-05-24.jpg"
+			 }
 		}
 	]
 }

--- a/erratas/43.json
+++ b/erratas/43.json
@@ -55,11 +55,11 @@
 			"atualizacao": "2019-05-14",
 			"conteudoAntigo": {
 				"tipo": "imagem",
-				"conteudo": "http://participe.comunicacao.smul.pmsp/arquivos/setor-central-2/errata/tabela1-antiga.jpg"
+				"conteudo": "https://participe.gestaourbana.prefeitura.sp.gov.br/arquivos/setor-central-2/errata/tabela1-antiga.jpg"
 			},
 			"conteudoNovo": { 
 				"tipo": "imagem",
-				"conteudo": "http://participe.comunicacao.smul.pmsp/arquivos/setor-central-2/errata/tabela1-2019-05-10.jpg"
+				"conteudo": "https://participe.gestaourbana.prefeitura.sp.gov.br/arquivos/setor-central-2/errata/tabela1-2019-05-10.jpg"
 			 }
 		},
 		{
@@ -139,11 +139,11 @@
 			"atualizacao": "2019-05-14",
 			"conteudoAntigo": {
 				"tipo": "imagem",
-				"conteudo": "http://participe.comunicacao.smul.pmsp/arquivos/setor-central-2/errata/tabela2-antiga.jpg"
+				"conteudo": "https://participe.gestaourbana.prefeitura.sp.gov.br/arquivos/setor-central-2/errata/tabela2-antiga.jpg"
 			},
 			"conteudoNovo": { 
 				"tipo": "imagem",
-				"conteudo": "http://participe.comunicacao.smul.pmsp/arquivos/setor-central-2/errata/tabela2-2019-05-10.jpg"
+				"conteudo": "https://participe.gestaourbana.prefeitura.sp.gov.br/arquivos/setor-central-2/errata/tabela2-2019-05-10.jpg"
 			 }
 		},
 		{
@@ -151,11 +151,11 @@
 			"atualizacao": "2019-05-14",
 			"conteudoAntigo": {
 				"tipo": "imagem",
-				"conteudo": "http://participe.comunicacao.smul.pmsp/arquivos/setor-central-2/img/distribuicao-estoque.png"
+				"conteudo": "https://participe.gestaourbana.prefeitura.sp.gov.br/arquivos/setor-central-2/img/distribuicao-estoque.png"
 			},
 			"conteudoNovo": { 
 				"tipo": "imagem",
-				"conteudo": "http://participe.comunicacao.smul.pmsp/arquivos/setor-central-2/img/distribuicao-estoque_2019-05-10.png"
+				"conteudo": "https://participe.gestaourbana.prefeitura.sp.gov.br/arquivos/setor-central-2/img/distribuicao-estoque_2019-05-10.png"
 			 }
 		},
 		{
@@ -163,11 +163,11 @@
 			"atualizacao": "2019-05-14",
 			"conteudoAntigo": {
 				"tipo": "imagem",
-				"conteudo": "http://participe.comunicacao.smul.pmsp/arquivos/setor-central-2/antes-depois/eixo-transf-minhocao_depois.jpg"
+				"conteudo": "https://participe.gestaourbana.prefeitura.sp.gov.br/arquivos/setor-central-2/antes-depois/eixo-transf-minhocao_depois.jpg"
 			},
 			"conteudoNovo": { 
 				"tipo": "imagem",
-				"conteudo": "http://participe.comunicacao.smul.pmsp/arquivos/setor-central-2/antes-depois/eixo-transf-minhocao_depois_2019-05-14.jpg"
+				"conteudo": "https://participe.gestaourbana.prefeitura.sp.gov.br/arquivos/setor-central-2/antes-depois/eixo-transf-minhocao_depois_2019-05-14.jpg"
 			 }
 		},
 		{
@@ -175,11 +175,11 @@
 			"atualizacao": "2019-05-15",
 			"conteudoAntigo": {
 				"tipo": "imagem",
-				"conteudo": "http://participe.comunicacao.smul.pmsp/arquivos/setor-central-2/antes-depois/eixo-ordena-paisa-4_depois.jpg"
+				"conteudo": "https://participe.gestaourbana.prefeitura.sp.gov.br/arquivos/setor-central-2/antes-depois/eixo-ordena-paisa-4_depois.jpg"
 			},
 			"conteudoNovo": { 
 				"tipo": "imagem",
-				"conteudo": "http://participe.comunicacao.smul.pmsp/arquivos/setor-central-2/antes-depois/eixo-ordena-paisa-4_depois_2019-05-15.jpg"
+				"conteudo": "https://participe.gestaourbana.prefeitura.sp.gov.br/arquivos/setor-central-2/antes-depois/eixo-ordena-paisa-4_depois_2019-05-15.jpg"
 			 }
 		},
 		{
@@ -187,11 +187,11 @@
 			"atualizacao": "2019-05-17",
 			"conteudoAntigo": {
 				"tipo": "imagem",
-				"conteudo": "http://participe.comunicacao.smul.pmsp/arquivos/setor-central-2/antes-depois/eixo-transf-orla_antes.jpg"
+				"conteudo": "https://participe.gestaourbana.prefeitura.sp.gov.br/arquivos/setor-central-2/antes-depois/eixo-transf-orla_antes.jpg"
 			},
 			"conteudoNovo": { 
 				"tipo": "imagem",
-				"conteudo": "http://participe.comunicacao.smul.pmsp/arquivos/setor-central-2/antes-depois/eixo-transf-orla_antes_2019-05-17.jpg"
+				"conteudo": "https://participe.gestaourbana.prefeitura.sp.gov.br/arquivos/setor-central-2/antes-depois/eixo-transf-orla_antes_2019-05-17.jpg"
 			 }
 		},
 		{
@@ -199,11 +199,11 @@
 			"atualizacao": "2019-05-17",
 			"conteudoAntigo": {
 				"tipo": "imagem",
-				"conteudo": "http://participe.comunicacao.smul.pmsp/arquivos/setor-central-2/antes-depois/eixo-transf-orla_depois.jpg"
+				"conteudo": "https://participe.gestaourbana.prefeitura.sp.gov.br/arquivos/setor-central-2/antes-depois/eixo-transf-orla_depois.jpg"
 			},
 			"conteudoNovo": { 
 				"tipo": "imagem",
-				"conteudo": "http://participe.comunicacao.smul.pmsp/arquivos/setor-central-2/antes-depois/eixo-transf-orla_depois_2019-05-17.jpg"
+				"conteudo": "https://participe.gestaourbana.prefeitura.sp.gov.br/arquivos/setor-central-2/antes-depois/eixo-transf-orla_depois_2019-05-17.jpg"
 			 }
 		}
 	]


### PR DESCRIPTION
Adiciona substituição de duas imagens em componente Antes Depois (Eixo de Transformação da Orla Fluvial)